### PR TITLE
Replace defines with const variables

### DIFF
--- a/src/butt.c
+++ b/src/butt.c
@@ -30,7 +30,7 @@ THE SOFTWARE.
 
 #include "conf.h"
 
-#define FILTER_TIME  70  /*  70 ms */
+static const tU08 filterTime_cU08 = 70;  /*  70 ms */
 
 static tButt_State_str buttState_str;
 
@@ -58,7 +58,7 @@ void Butt_Loop(void)
     }
 
     /* Check if raw value is stable */
-    if ((buttonRawOld_str.tickInState_U08 >= FILTER_TIME / TICK) &&
+    if ((buttonRawOld_str.tickInState_U08 >= filterTime_cU08 / TICK) &&
         (buttState_str.state_E != buttonRaw_E))
     {
         buttState_str.state_E = buttonRaw_E;

--- a/src/buzz.c
+++ b/src/buzz.c
@@ -33,11 +33,11 @@ THE SOFTWARE.
 #include "conf.h"
 #include "type.h"
 
-#define BUZZ_ALARM_PERIOD_TIME 2000 /* [ms]*/
-#define BUZZER_FREQ 600UL /* [Hz] */
+static const tU16 buzzAlarmPeriodTime_cU16 = 2000; /* [ms]*/
+static const tU16 buzzerFreq_cU16 = 600; /* [Hz] */
 #if defined(__AVR_ATtiny13A__)
 /* Lower this for lower consumption and sound level. */
-#define BUZZER_DUTY_CYCLE 10UL /* [%] */
+static const tU08 buzzerDutyCycle_cU08 = 10; /* [%] */
 #endif
 
 static tBuzz_SoundType_E soundType_E;
@@ -52,10 +52,10 @@ void Buzz_Init(void)
  * In this case gives a buzzer frequency of 1690 Hz
  */
 #if F_CPU == 8000000 && defined(__AVR_ATtiny85__)
-    OCR0A = F_CPU / (BUZZER_FREQ * 64 * 2) - 1;
+    OCR0A = F_CPU / (buzzerFreq_cU16 * 64 * 2) - 1;
 #elif F_CPU == 9600000 && defined(__AVR_ATtiny13A__)
-    OCR0A = F_CPU / (BUZZER_FREQ * 64) - 1;
-    OCR0B = (F_CPU / (BUZZER_FREQ * 64) - 1) * BUZZER_DUTY_CYCLE / 100;
+    OCR0A = F_CPU / (buzzerFreq_cU16 * 64) - 1;
+    OCR0B = (F_CPU / (buzzerFreq_cU16 * 64) - 1) * buzzerDutyCycle_cU08 / 100;
 #else
 #error "Buzzer module does not support this combination of MCU and clock frequency";
 #endif
@@ -72,11 +72,11 @@ void Buzz_Loop(void)
     }
     else if (soundType_E == BUZZ_ALARM_E)
     {
-        if (++counter_U08 > BUZZ_ALARM_PERIOD_TIME / TICK)
+        if (++counter_U08 > buzzAlarmPeriodTime_cU16 / TICK)
         {
             counter_U08 = 0;
         }
-        if (counter_U08 < BUZZ_ALARM_PERIOD_TIME / TICK / 2)
+        if (counter_U08 < buzzAlarmPeriodTime_cU16 / TICK / 2)
         {
             turnOn();
         }

--- a/src/door.c
+++ b/src/door.c
@@ -29,20 +29,22 @@ THE SOFTWARE.
 #include "door.h"
 
 #include <avr/io.h>
+#include <stdlib.h>
 #include <util/delay.h>
 
 #include "conf.h"
 #include "eepr.h"
 
+
 /**
  * Due to ~0.135 V supply loss to sensor compared with supply to ADC-converter
  * the normal ADC-range will be 0-986 instead of 0-1023.
  */
-#define UNAFFECTED_SENSOR_VALUE 493
+static const tU16 unaffectedSensorValue_cU16 = 493;
 /* Offset from stored position to trigger alarm. [-]*/
-#define DOOR_CLOSED_OFFSET 20
+static const tU08 doorClosedOffset_cU08 = 20;
 /* Minimum accepted door position (calculated offset from 512) [-] */
-#define MIN_CAL_DOOR_CLOSED_POS 60
+static const tU08 minCalDoorClosedPos_cU08 = 60;
 
 static tDoor_State_str doorState_str;
 static tU16 doorClosed_U16;
@@ -79,9 +81,9 @@ void Door_Loop(void)
 
     tDoor_Position_E newposition_E;
     /* Algorithm handles both direction of magnet field */
-    if (doorClosed_U16 < UNAFFECTED_SENSOR_VALUE)
+    if (doorClosed_U16 < unaffectedSensorValue_cU16)
     {
-        if (doorPos_U16 > doorClosed_U16 + DOOR_CLOSED_OFFSET)
+        if (doorPos_U16 > doorClosed_U16 + doorClosedOffset_cU08)
         {
             newposition_E = DOOR_OPEN_E;
         }
@@ -92,7 +94,7 @@ void Door_Loop(void)
     }
     else
     {
-        if (doorPos_U16 < doorClosed_U16 - DOOR_CLOSED_OFFSET)
+        if (doorPos_U16 < doorClosed_U16 - doorClosedOffset_cU08)
         {
             newposition_E = DOOR_OPEN_E;
         }
@@ -181,7 +183,7 @@ static tB withinRange_B(const tU16 sensorValue_U16)
 {
     tB ret_B = FALSE;
     /* Cast should not be a problem due to the 10-bit resolution. */
-    if (ABS((tS16)sensorValue_U16 - UNAFFECTED_SENSOR_VALUE) > MIN_CAL_DOOR_CLOSED_POS)
+    if (abs((tS16)sensorValue_U16 - (tS16)unaffectedSensorValue_cU16) > minCalDoorClosedPos_cU08)
     {
         ret_B = TRUE;
     }

--- a/src/ledc.c
+++ b/src/ledc.c
@@ -32,7 +32,7 @@ THE SOFTWARE.
 #include "conf.h"
 #include "type.h"
 
-#define BLINK_PERIOD_TIME 120 /* ms */
+static const tU08 blinkPeriodTime_cU08 = 120; /* ms */
 
 static tLedc_State_E ledState_E = LEDC_OFF_E;
 
@@ -46,7 +46,7 @@ void Ledc_Init(void)
 void Ledc_Loop(void)
 {
     static tU08 counter_U08;
-    if (++counter_U08 > BLINK_PERIOD_TIME / TICK)
+    if (++counter_U08 > blinkPeriodTime_cU08 / TICK)
     {
         counter_U08 = 0;
     }
@@ -73,7 +73,7 @@ void Ledc_Loop(void)
         break;
 
     case LEDC_GREEN_BLINK_E:
-        if (counter_U08 > BLINK_PERIOD_TIME / TICK / 2)
+        if (counter_U08 > blinkPeriodTime_cU08 / TICK / 2)
         {
             IO_SET(GREEN_LED_CFG);
         }
@@ -85,7 +85,7 @@ void Ledc_Loop(void)
         break;
 
     case LEDC_RED_BLINK_E:
-        if (counter_U08 > BLINK_PERIOD_TIME / TICK / 2)
+        if (counter_U08 > blinkPeriodTime_cU08 / TICK / 2)
         {
             IO_SET(RED_LED_CFG);
         }

--- a/src/type.h
+++ b/src/type.h
@@ -88,7 +88,6 @@ typedef signed int tS16;
 
 /* MATH MACRO DEFINITIONS */
 
-#define ABS(a)     (((a) < 0) ? -(a) : (a))
 #define INC_U08(a) ((a) == MAX_U08 ? MAX_U08 : (a)++)
 #define INC_U16(a) ((a) == MAX_U16 ? MAX_U16 : (a)++)
 #define LO(a)      ((tU08)((a) & 0xFF))

--- a/src/wcet.c
+++ b/src/wcet.c
@@ -27,7 +27,7 @@ THE SOFTWARE.
 #include "wcet.h"
 #include "uart.h"
 
-static tU08 crc8_U08 (tU08 inCrc, tU08 inData);
+static tU08 crc8_U08 (tU08 inCrc_U08, tU08 inData_U08);
 
 FORCE_INLINE void Wcet_StopMeasurement(void)
 {


### PR DESCRIPTION
Replace defines with const variables for better debugging possibilities
and type checkning.
Replace ABS macro with stdlib abs().

Fixes #79.